### PR TITLE
Add FIRE calculator and central CTA logic

### DIFF
--- a/fire.html
+++ b/fire.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>FIRE Calculator - Cruncher.Money</title>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-6Q7ZTXJBC2"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-6Q7ZTXJBC2');
+
+    document.body?.addEventListener('click', function (e) {
+      const link = e.target.closest('a');
+      if (link && link.href && link.hostname !== location.hostname && window.gtag) {
+        gtag('event', 'click', {
+          event_category: 'outbound',
+          event_label: link.href
+        });
+      }
+    });
+  </script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body {
+      font-family: 'Inter', sans-serif;
+      background: #f4f7fb;
+      margin: 0;
+      padding: 2em;
+      color: #0a0a0a;
+    }
+    .cc-card {
+      background: white;
+      padding: 2em;
+      max-width: 600px;
+      margin: 2em auto;
+      border-radius: 12px;
+      box-shadow: 0 0 12px rgba(0,0,0,0.05);
+    }
+    .cc-group { margin-top: 1.5em; }
+    .cc-group label { font-weight: 600; }
+    .cc-subtle { color: #555; font-size: 0.9em; margin-left: 0.5em; }
+    .cc-button {
+      background: #007AFF;
+      color: white;
+      border: none;
+      padding: 12px;
+      width: 100%;
+      border-radius: 6px;
+      font-weight: 600;
+    }
+    .results { display: none; margin-top: 1em; }
+    .cc-region { display: none; margin-top: 1em; font-size: 0.95em; }
+    .cc-region a { color: #007AFF; text-decoration: none; font-weight: bold; }
+  </style>
+</head>
+<body>
+  <div class="cc-card">
+    <h2>FIRE Calculator</h2>
+    <div class="cc-group">
+      <label>Current Savings (<span class="cc-subtle" id="savingsDisplay">€50,000</span>)</label>
+      <input type="range" id="fireSavings" min="0" max="2000000" step="1000" value="50000" oninput="document.getElementById('savingsDisplay').innerText = currSymbol + parseInt(this.value).toLocaleString()">
+    </div>
+    <div class="cc-group">
+      <label>Monthly Contribution (<span class="cc-subtle" id="contribDisplay">€1,000</span>)</label>
+      <input type="range" id="fireContrib" min="0" max="20000" step="100" value="1000" oninput="document.getElementById('contribDisplay').innerText = currSymbol + parseInt(this.value).toLocaleString()">
+    </div>
+    <div class="cc-group">
+      <label>Expected Annual Return % (<span class="cc-subtle" id="returnDisplay">6%</span>)</label>
+      <input type="range" id="fireReturn" min="1" max="15" step="0.1" value="6" oninput="document.getElementById('returnDisplay').innerText = this.value + '%'">
+    </div>
+    <div class="cc-group">
+      <label>Target Annual Expenses (<span class="cc-subtle" id="expenseDisplay">€40,000</span>)</label>
+      <input type="range" id="fireExpenses" min="10000" max="200000" step="1000" value="40000" oninput="document.getElementById('expenseDisplay').innerText = currSymbol + parseInt(this.value).toLocaleString()">
+    </div>
+    <button onclick="calculateFire()" class="cc-button">Calculate</button>
+    <div class="results" id="fireResults">
+      <p id="yearsToFire"></p>
+      <p id="fireValue"></p>
+      <canvas id="fireChart" width="400" height="200"></canvas>
+      <div class="cc-region" id="ctaFire"></div>
+    </div>
+  </div>
+
+<script>
+  const currencySymbol = {
+    IE: '€',
+    GB: '£',
+    US: '$',
+    CA: '$',
+    AU: '$',
+    IN: '₹',
+    FR: '€',
+    DE: '€',
+    default: '€'
+  };
+
+  const ctaLinks = {
+    IE: { flag: '🇮🇪', affiliate: true,
+      mortgage: 'https://switcher.ie/mortgages',
+      savings: 'https://bonkers.ie/compare-savings-accounts/',
+      fire: 'https://switcher.ie/investments/',
+      pension: '' },
+    GB: { flag: '🇬🇧', affiliate: true,
+      mortgage: 'https://moneyfacts.co.uk/mortgages',
+      savings: 'https://moneyfacts.co.uk/savings-accounts/',
+      fire: 'https://moneysavingexpert.com/savings/investment-beginners/',
+      pension: '' },
+    US: { flag: '🇺🇸', affiliate: true,
+      mortgage: 'https://nerdwallet.com/mortgages',
+      savings: 'https://nerdwallet.com/best/banking/savings-accounts',
+      fire: 'https://nerdwallet.com/investing/retirement/fire-movement',
+      pension: '' },
+    CA: { flag: '🇨🇦', affiliate: true,
+      mortgage: 'https://ratehub.ca/mortgage-rates',
+      savings: 'https://ratehub.ca/high-interest-savings-accounts',
+      fire: null, pension: '' },
+    AU: { flag: '🇦🇺', affiliate: true,
+      mortgage: 'https://mozo.com.au/home-loans',
+      savings: 'https://mozo.com.au/savings-accounts',
+      fire: null, pension: '' },
+    FR: { flag: '🇫🇷', affiliate: false,
+      mortgage: 'https://meilleurtaux.com/',
+      savings: 'https://lelynx.fr/banque/comparateur/livret-epargne/',
+      fire: null, pension: '' },
+    DE: { flag: '🇩🇪', affiliate: false,
+      mortgage: 'https://check24.de/',
+      savings: 'https://check24.de/tagesgeld/',
+      fire: null, pension: '' },
+    IN: { flag: '🇮🇳', affiliate: false,
+      mortgage: 'https://bankbazaar.com/home-loan.html',
+      savings: 'https://bankbazaar.com/savings-account.html',
+      fire: null, pension: '' },
+    default: { flag: '🌍', affiliate: false,
+      mortgage: 'https://www.google.com/search?q=compare+mortgage+rates+${country_name}',
+      savings: 'https://www.google.com/search?q=best+savings+accounts+${country_name}',
+      fire: 'https://www.google.com/search?q=fire+movement+${country_name}',
+      pension: '' }
+  };
+
+  let currSymbol = '€';
+  let fireChart;
+
+  fetch('https://ipapi.co/json/')
+    .then(res => res.json())
+    .then(data => {
+      const country = data.country_code;
+      const name = data.country_name || 'your region';
+      currSymbol = currencySymbol[country] || currencySymbol.default;
+
+      showCTA('fire', 'ctaFire', country, name);
+      updateCurrencyDisplays();
+    })
+    .catch(() => {
+      showCTA('fire', 'ctaFire', 'default', 'your region');
+    });
+
+  function showCTA(type, id, code, name) {
+    const data = ctaLinks[code] || ctaLinks.default;
+    let url = data[type];
+    let flag = data.flag;
+    if (!url) {
+      url = ctaLinks.default[type].replace('${country_name}', encodeURIComponent(name));
+      flag = ctaLinks.default.flag;
+    } else {
+      url = url.replace('${country_name}', encodeURIComponent(name));
+    }
+    if (!url) return;
+    const el = document.getElementById(id);
+    if (el) {
+      const textMap = {
+        fire: `Learn about FIRE in ${name}`
+      };
+      el.innerHTML = `<a href="${url}" target="_blank">${flag} ${textMap[type]}</a>`;
+      el.style.display = 'block';
+    }
+  }
+
+  function updateCurrencyDisplays() {
+    document.getElementById('savingsDisplay').innerText = currSymbol + parseInt(document.getElementById('fireSavings').value).toLocaleString();
+    document.getElementById('contribDisplay').innerText = currSymbol + parseInt(document.getElementById('fireContrib').value).toLocaleString();
+    document.getElementById('expenseDisplay').innerText = currSymbol + parseInt(document.getElementById('fireExpenses').value).toLocaleString();
+  }
+
+  function calculateFire() {
+    const savings = parseFloat(document.getElementById('fireSavings').value);
+    const monthly = parseFloat(document.getElementById('fireContrib').value);
+    const annual = parseFloat(document.getElementById('fireReturn').value) / 100;
+    const expenses = parseFloat(document.getElementById('fireExpenses').value);
+    const target = expenses * 25;
+    let balance = savings;
+    let months = 0;
+    const labels = [0];
+    const dataPoints = [balance];
+    while (balance < target && months < 1000) {
+      balance = balance * (1 + annual / 12) + monthly;
+      months++;
+      if (months % 12 === 0 || balance >= target) {
+        labels.push((months / 12).toFixed(1));
+        dataPoints.push(balance);
+      }
+    }
+    const years = months / 12;
+    document.getElementById('yearsToFire').innerText = `Years to FIRE: ${years.toFixed(1)}`;
+    document.getElementById('fireValue').innerText = `Projected portfolio at FIRE: ${currSymbol}${Math.round(balance).toLocaleString()}`;
+    document.getElementById('fireResults').style.display = 'block';
+
+    if (fireChart) fireChart.destroy();
+    const ctx = document.getElementById('fireChart').getContext('2d');
+    fireChart = new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: labels,
+        datasets: [{ label: 'Portfolio', data: dataPoints, borderColor: '#007AFF', fill: false }]
+      },
+      options: {
+        scales: {
+          x: { title: { display: true, text: 'Years' } },
+          y: { title: { display: true, text: 'Value' } }
+        }
+      }
+    });
+  }
+</script>
+<footer style="font-size: 0.85em; color: #555; text-align: center; margin-top: 3em; padding-top: 2em; border-top: 1px solid #ddd;">
+  <p>⚠️ These calculators are for informational purposes only and do not constitute financial advice.</p>
+  <p>
+    <a href="/about.html">About</a> |
+    <a href="/disclaimer.html">Disclaimer</a> |
+    <a href="/">Home</a>
+  </p>
+  <p style="margin-top: 1em;">&copy; 2024 Cruncher.Money</p>
+</footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -78,15 +78,7 @@
     <div class="results" id="ltvResults">
       <p id="ltvRatio"></p>
       <p id="ltvEquity"></p>
-      <div class="cc-region" data-region="IE"><a href="https://switcher.ie/mortgages" target="_blank">🇮🇪 Compare Irish mortgage offers</a></div>
-      <div class="cc-region" data-region="GB"><a href="https://moneyfacts.co.uk/mortgages" target="_blank">🇬🇧 Find UK mortgage switch deals</a></div>
-      <div class="cc-region" data-region="US"><a href="https://www.nerdwallet.com/mortgages" target="_blank">🇺🇸 Check current U.S. mortgage rates</a></div>
-      <div class="cc-region" data-region="CA"><a href="https://www.ratehub.ca/mortgage-rates" target="_blank">🇨🇦 See Canadian mortgage offers</a></div>
-      <div class="cc-region" data-region="AU"><a href="https://mozo.com.au/home-loans" target="_blank">🇦🇺 Compare Australian mortgage rates</a></div>
-      <div class="cc-region" data-region="IN"><a href="https://www.bankbazaar.com/" target="_blank">🇮🇳 Explore Indian banking offers</a></div>
-      <div class="cc-region" data-region="FR"><a href="https://www.meilleurtaux.com/" target="_blank">🇫🇷 Compare French mortgage options</a></div>
-      <div class="cc-region" data-region="DE"><a href="https://www.check24.de/" target="_blank">🇩🇪 Compare German mortgage rates</a></div>
-      <div class="cc-region" data-region="default"><p>🌍 We don’t yet have a partner for your region. Try searching: <a class="googleLink" href="#" target="_blank">top bank rates in your country</a>.</p></div>
+      <div class="cc-region" id="ctaLTV"></div>
     </div>
   </div>
 
@@ -112,15 +104,7 @@
     <div class="results" id="resultsBox">
       <p><strong>Time Saved:</strong><br><span id="timeSaved"></span></p>
       <p><strong>Interest Saved:</strong><br><span id="interestSaved"></span></p>
-      <div class="cc-region" data-region="IE"><a href="https://switcher.ie/mortgages" target="_blank">🇮🇪 Compare Irish mortgage offers</a></div>
-      <div class="cc-region" data-region="GB"><a href="https://moneyfacts.co.uk/mortgages" target="_blank">🇬🇧 Find UK mortgage switch deals</a></div>
-      <div class="cc-region" data-region="US"><a href="https://www.nerdwallet.com/mortgages" target="_blank">🇺🇸 Check current U.S. mortgage rates</a></div>
-      <div class="cc-region" data-region="CA"><a href="https://www.ratehub.ca/mortgage-rates" target="_blank">🇨🇦 See Canadian mortgage offers</a></div>
-      <div class="cc-region" data-region="AU"><a href="https://mozo.com.au/home-loans" target="_blank">🇦🇺 Compare Australian mortgage rates</a></div>
-      <div class="cc-region" data-region="IN"><a href="https://www.bankbazaar.com/" target="_blank">🇮🇳 Explore Indian banking offers</a></div>
-      <div class="cc-region" data-region="FR"><a href="https://www.meilleurtaux.com/" target="_blank">🇫🇷 Compare French mortgage options</a></div>
-      <div class="cc-region" data-region="DE"><a href="https://www.check24.de/" target="_blank">🇩🇪 Compare German mortgage rates</a></div>
-      <div class="cc-region" data-region="default"><p>🌍 We don’t yet have a partner for your region. Try searching: <a class="googleLink" href="#" target="_blank">top bank rates in your country</a>.</p></div>
+      <div class="cc-region" id="ctaOverpay"></div>
     </div>
   </div>
 
@@ -143,15 +127,7 @@
       <p id="monthlyNeeded"></p>
       <p id="totalContributed"></p>
       <p id="interestEarned"></p>
-      <div class="cc-region" data-region="IE"><a href="https://switcher.ie/mortgages" target="_blank">🇮🇪 Compare Irish mortgage offers</a></div>
-      <div class="cc-region" data-region="GB"><a href="https://moneyfacts.co.uk/mortgages" target="_blank">🇬🇧 Find UK mortgage switch deals</a></div>
-      <div class="cc-region" data-region="US"><a href="https://www.nerdwallet.com/mortgages" target="_blank">🇺🇸 Check current U.S. mortgage rates</a></div>
-      <div class="cc-region" data-region="CA"><a href="https://www.ratehub.ca/mortgage-rates" target="_blank">🇨🇦 See Canadian mortgage offers</a></div>
-      <div class="cc-region" data-region="AU"><a href="https://mozo.com.au/home-loans" target="_blank">🇦🇺 Compare Australian mortgage rates</a></div>
-      <div class="cc-region" data-region="IN"><a href="https://www.bankbazaar.com/" target="_blank">🇮🇳 Explore Indian banking offers</a></div>
-      <div class="cc-region" data-region="FR"><a href="https://www.meilleurtaux.com/" target="_blank">🇫🇷 Compare French mortgage options</a></div>
-      <div class="cc-region" data-region="DE"><a href="https://www.check24.de/" target="_blank">🇩🇪 Compare German mortgage rates</a></div>
-      <div class="cc-region" data-region="default"><p>🌍 We don’t yet have a partner for your region. Try searching: <a class="googleLink" href="#" target="_blank">top bank rates in your country</a>.</p></div>
+        <div class="cc-region" id="ctaSavings"></div>
     </div>
   </div>
 
@@ -168,38 +144,93 @@
       default: '€'
     };
 
+    const ctaLinks = {
+      IE: { flag: '🇮🇪', affiliate: true,
+        mortgage: 'https://switcher.ie/mortgages',
+        savings: 'https://bonkers.ie/compare-savings-accounts/',
+        fire: 'https://switcher.ie/investments/',
+        pension: '' },
+      GB: { flag: '🇬🇧', affiliate: true,
+        mortgage: 'https://moneyfacts.co.uk/mortgages',
+        savings: 'https://moneyfacts.co.uk/savings-accounts/',
+        fire: 'https://moneysavingexpert.com/savings/investment-beginners/',
+        pension: '' },
+      US: { flag: '🇺🇸', affiliate: true,
+        mortgage: 'https://nerdwallet.com/mortgages',
+        savings: 'https://nerdwallet.com/best/banking/savings-accounts',
+        fire: 'https://nerdwallet.com/investing/retirement/fire-movement',
+        pension: '' },
+      CA: { flag: '🇨🇦', affiliate: true,
+        mortgage: 'https://ratehub.ca/mortgage-rates',
+        savings: 'https://ratehub.ca/high-interest-savings-accounts',
+        fire: null, pension: '' },
+      AU: { flag: '🇦🇺', affiliate: true,
+        mortgage: 'https://mozo.com.au/home-loans',
+        savings: 'https://mozo.com.au/savings-accounts',
+        fire: null, pension: '' },
+      FR: { flag: '🇫🇷', affiliate: false,
+        mortgage: 'https://meilleurtaux.com/',
+        savings: 'https://lelynx.fr/banque/comparateur/livret-epargne/',
+        fire: null, pension: '' },
+      DE: { flag: '🇩🇪', affiliate: false,
+        mortgage: 'https://check24.de/',
+        savings: 'https://check24.de/tagesgeld/',
+        fire: null, pension: '' },
+      IN: { flag: '🇮🇳', affiliate: false,
+        mortgage: 'https://bankbazaar.com/home-loan.html',
+        savings: 'https://bankbazaar.com/savings-account.html',
+        fire: null, pension: '' },
+      default: { flag: '🌍', affiliate: false,
+        mortgage: 'https://www.google.com/search?q=compare+mortgage+rates+${country_name}',
+        savings: 'https://www.google.com/search?q=best+savings+accounts+${country_name}',
+        fire: 'https://www.google.com/search?q=fire+movement+${country_name}',
+        pension: '' }
+    };
+
     let currSymbol = '€';
 
     fetch('https://ipapi.co/json/')
       .then(res => res.json())
       .then(data => {
         const country = data.country_code;
+        const name = data.country_name || 'your region';
         currSymbol = currencySymbol[country] || currencySymbol.default;
 
-        document.querySelectorAll('.results').forEach(box => {
-          const regions = box.querySelectorAll('.cc-region');
-          let found = false;
-          regions.forEach(el => {
-            if (el.dataset.region === country) {
-              el.style.display = 'block';
-              found = true;
-            }
-          });
-          if (!found) {
-            const fallback = box.querySelector('.cc-region[data-region="default"]');
-            if (fallback) {
-              fallback.style.display = 'block';
-              fallback.querySelectorAll('.googleLink').forEach(link => {
-                if (data.country_name) {
-                  link.href = `https://www.google.com/search?q=compare+bank+rates+${encodeURIComponent(data.country_name)}`;
-                }
-              });
-            }
-          }
-        });
+        showCTA('mortgage', 'ctaLTV', country, name);
+        showCTA('mortgage', 'ctaOverpay', country, name);
+        showCTA('savings', 'ctaSavings', country, name);
 
         updateCurrencyDisplays();
+      })
+      .catch(() => {
+        showCTA('mortgage', 'ctaLTV', 'default', 'your region');
+        showCTA('mortgage', 'ctaOverpay', 'default', 'your region');
+        showCTA('savings', 'ctaSavings', 'default', 'your region');
       });
+
+    function showCTA(type, id, code, name) {
+      const data = ctaLinks[code] || ctaLinks.default;
+      let url = data[type];
+      let flag = data.flag;
+      if (!url) {
+        url = ctaLinks.default[type].replace('${country_name}', encodeURIComponent(name));
+        flag = ctaLinks.default.flag;
+      } else {
+        url = url.replace('${country_name}', encodeURIComponent(name));
+      }
+      if (!url) return;
+      const el = document.getElementById(id);
+      if (el) {
+        const textMap = {
+          mortgage: `Compare ${name} mortgage offers`,
+          savings: `Explore ${name} savings rates`,
+          fire: `Learn about FIRE in ${name}`,
+          pension: `Explore ${name} pension options`
+        };
+        el.innerHTML = `<a href="${url}" target="_blank">${flag} ${textMap[type]}</a>`;
+        el.style.display = 'block';
+      }
+    }
 
     function updateCurrencyDisplays() {
       document.getElementById('valueDisplay').innerText = currSymbol + parseInt(document.getElementById('ltvValue').value).toLocaleString();


### PR DESCRIPTION
## Summary
- centralise CTA links and currency symbols
- dynamically insert region-specific links and flags in calculators
- add standalone `fire.html` page with FIRE calculator and chart

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852f0a0016c8332a01186e390222d57